### PR TITLE
Spelling fixes for Border Zone (against develop branch)

### DIFF
--- a/bad.zil
+++ b/bad.zil
@@ -2602,7 +2602,7 @@ of the hall.")
       (DESC "Hallway, South")
       (FDESC "southern part of the hallway")
       (LDESC
-"You are about one-third of the way betwween the southern and northern
+"You are about one-third of the way between the southern and northern
 ends of the hallway. Doors are on both sides of you, east and west.")
       (NORTH TO HALL-3 IF FALSE-FLAG ELSE
 "You continue down the hall to the next set of doorways, one to the east

--- a/bad.zil
+++ b/bad.zil
@@ -601,7 +601,7 @@ the back room and take you into custody." CR>
 	 <COND (<VERB? LISTEN FOLLOW EXAMINE>
 		<TELL
 "You can't make out every word, but the police are questioning your friend
-about certain acquaintences, affiliations, and the like." CR>)
+about certain acquaintances, affiliations, and the like." CR>)
 	       (T
 		<TELL "Bizarre." CR>)>>
 

--- a/bad.zil
+++ b/bad.zil
@@ -299,7 +299,7 @@ the street, to the west, lies a vacant lot." CR>
       (DESC "Near Empty Lot")
       (FDESC "spot directly across from the vacant lot")
       (LDESC
-"You are on Fremzi Stret, halfway between Brzni to the north and Besnap
+"You are on Fremzi Street, halfway between Brzni to the north and Besnap
 to the south. A vacant lot sits to the west; two buildings rise to the
 northeast and southeast, but access to the inside is on Ostnitz Street.")
       (NORTH PER BB1-MOVE)
@@ -611,7 +611,7 @@ about certain acquaintences, affiliations, and the like." CR>)
       (PATH-TIME 0)
       (DESC "Side Entrance")
       (LDESC
-"This is as far as you can go on Fremzi Stret, before running into the
+"This is as far as you can go on Fremzi Street, before running into the
 police cordons. A metal door, closed and locked, lies to the east.
 On it, a sign reads \"Riznik's Antiques - Deliveries Only\"")
       (FDESC "side entrance of the antique store")

--- a/border.zil
+++ b/border.zil
@@ -3530,7 +3530,7 @@ preparing to depart." CR>)>>
 inexpensively built hut like this." CR>)
 	       (<VERB? KNOCK>
 		<TELL
-"Not smart; sombody might hear you." CR>)
+"Not smart; somebody might hear you." CR>)
 	       (<VERB? MUNG KICK>
 		<TELL
 "Not smart. If somebody's home, you're in big trouble, and if nobody's

--- a/border.zil
+++ b/border.zil
@@ -4381,7 +4381,7 @@ continues along here to the southwest.")
 face. The road bends to the east here, but a narrow spur continues north.")
       (NE TO E6 IF HACK-FLAG ELSE
 "A brisk wind gives you a deep chill, but you reenter the forest. Soon,
-you rejoint the road which now is running from east to west.")
+you rejoin the road which now is running from east to west.")
 
       (NW TO C6 IF HACK-FLAG ELSE
 "You leave the side of the roadway and enter the forest, proceeding a

--- a/border.zil
+++ b/border.zil
@@ -3246,7 +3246,7 @@ in flames, and the heat and smoke make it hard to get much closer." CR>)
 		      (T
 		       <TELL
 "The hut is small, perhaps no more than a few rooms. The exterior is a
-dark wooden clapboard, worn and weaterbeaten. Some black smoke rises out
+dark wooden clapboard, worn and weatherbeaten. Some black smoke rises out
 of a small chimney, swirling around in the cold breeze, and vanishing
 into the night sky." CR>)>)
 	       (<VERB? CLIMB CLIMB-OVER CLIMB-UP>

--- a/bystander.zil
+++ b/bystander.zil
@@ -109,7 +109,7 @@ distance the darkness that is Litzenburg.">)
 	       (<EQUAL? .RM ,PLATFORM-4>
 		<TELL CR CR
 "You've arrived at the platform's southern end, and can look back into
-Frobnia, sighting its formidible border defenses: guard towers, searchlights,
+Frobnia, sighting its formidable border defenses: guard towers, searchlights,
 patrols, guard dogs - God knows what else. It's a whole lot better to have a
 ticket, and you smile, realizing that it's not easy this way either.">)>
 	 <CRLF>

--- a/bystander.zil
+++ b/bystander.zil
@@ -1798,7 +1798,7 @@ Copyright (c) 1987, Infocom, Inc.|
 	 <COND (<VERB? EXAMINE>
 		<TELL
 "It's your ordinary metal towel dispenser. Here, as in the States, people
-tend to write grafitti on towel dispensers, and this one is no exception.">
+tend to write graffiti on towel dispensers, and this one is no exception.">
 		<COND (<IN? ,PAPER-TOWEL ,PRSO>
 		       <TELL
 " You are in luck - there's at least one paper towel inside.">)

--- a/good.zil
+++ b/good.zil
@@ -415,7 +415,7 @@ Perhaps where there's smoke there will be warmth.">)>
 		<BOLDTELL "You're feeling a lot warmer now.">)>>
 
 <GLOBAL WARMTH-TBL
-	<PTABLE "You're shaking uncontrollably from the cold. It won't be long before you are competely incapacitated."
+	<PTABLE "You're shaking uncontrollably from the cold. It won't be long before you are completely incapacitated."
 	       "You're shivering badly. If you don't find some warmth soon, it's hard to see how you can go on."
 	       "Your teeth start to chatter from the cold; you are clearly slowing down, both physically and mentally."
 	       "You've got quite a chill; you must move now to keep warm, but even this is not enough."

--- a/good.zil
+++ b/good.zil
@@ -1315,7 +1315,7 @@ the rear of the hut. Fortunately, he isn't looking inside."
 		      BEHIND-HUT>
 	       <PTABLE ROAD-END HUT-BEDROOM
 		      "You can see a single guard slowly walking around the back side of the hut to the south side of the hut."
-		      "Through the window, a lone guard comes into view, awalking slowly toward the front of the hut. Fortunately, he isn't looking in your direction." 
+		      "Through the window, a lone guard comes into view, walking slowly toward the front of the hut. Fortunately, he isn't looking in your direction." 
 		      SOUTH-HUT>
 	       <PTABLE NORTH-HUT 0
 		      "You watch as the lone guard returns to the group. He appears relieved that he has nothing to report."

--- a/hints.zil
+++ b/hints.zil
@@ -421,7 +421,7 @@ the American agent?"
 		 "A variety of reasons. First, anything you do that might cause him to think you're intent on defeating him will get you killed. Also, arriving at his door while you're being pursued is a definite killer.">
       <NEW-HINT H-TOPAZ
 		 "How can I avoid Topaz?"
-		 "Once he's seen you, he will doggedly pursue you for the remainder of your alloted time (i.e. until the assassination happens.)"
+		 "Once he's seen you, he will doggedly pursue you for the remainder of your allotted time (i.e. until the assassination happens.)"
 		 "He can be avoided by staying away from the cafe. The more you pass by there or spend time there, the more likely that he'll see you."
 		 "Maybe you don't want to avoid him...">
       <NEW-HINT H-TOPAZ-HELP


### PR DESCRIPTION
These are the spelling fixes for Border Zone from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.